### PR TITLE
Fix for some issues that I ran into with Ravello

### DIFF
--- a/TestPrereq.ps1
+++ b/TestPrereq.ps1
@@ -78,6 +78,10 @@ Enable-WindowsOptionalFeature -Online -FeatureName WCF-Pipe-Activation45
 Enable-WindowsOptionalFeature -Online -FeatureName WCF-MSMQ-Activation45
 Enable-WindowsOptionalFeature -Online -FeatureName WCF-TCP-PortSharing45
 
+#ensure that NetTcpPortSharing service is set to automatic, and is started
+Set-Service NetTcpPortSharing -StartupType Automatic
+Start-Service NetTcpPortSharing
+
 
 Write-Host ([Environment]::NewLine)
 Write-Host "OK, good to go! Continue installing the lab."

--- a/TestPrereq.ps1
+++ b/TestPrereq.ps1
@@ -67,6 +67,17 @@ Test-PowerShellVersion
 Test-Net45
 Test-Sql
 
+#ensure required windows features are installed
+Import-Module Dism
+Enable-WindowsOptionalFeature -Online -FeatureName WCF-HTTP-Activation
+Enable-WindowsOptionalFeature -Online -FeatureName WCF-NonHTTP-Activation
+Enable-WindowsOptionalFeature -Online -FeatureName WCF-Services45
+Enable-WindowsOptionalFeature -Online -FeatureName WCF-HTTP-Activation45
+Enable-WindowsOptionalFeature -Online -FeatureName WCF-TCP-Activation45
+Enable-WindowsOptionalFeature -Online -FeatureName WCF-Pipe-Activation45
+Enable-WindowsOptionalFeature -Online -FeatureName WCF-MSMQ-Activation45
+Enable-WindowsOptionalFeature -Online -FeatureName WCF-TCP-PortSharing45
+
 
 Write-Host ([Environment]::NewLine)
 Write-Host "OK, good to go! Continue installing the lab."

--- a/TestPrereq.ps1
+++ b/TestPrereq.ps1
@@ -21,22 +21,17 @@ Function Test-PowerShellVersion
 
 Function Test-Net45
 {
-    $path = 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full'
-
-	if (Test-Path $path)
-	{
-		if (Get-ItemProperty $path -Name Version -ErrorAction SilentlyContinue)
-		{
-			$reg = Get-ItemProperty $path
-			$v = [version]$reg.Version
-			$v45 = [version]"4.5.0"
-			if($v -ge $v45)
-			{
-				return
-			}
-		}
-	}
-
+	
+   #get installed versions of .NET that are either 4.5 or 4.6
+   $installedVersions = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP' -recurse |
+	Get-ItemProperty -name Version,Release -EA 0 |
+	Where { $_.PSChildName -match '^(?!S)\p{L}'} |
+        Where { $_.Version -match '^4.[5,6].' }
+    if ($installedVersions.Length -gt 0) {
+    	#one or more supported versions installed
+    	return
+    }
+    
     Write-Warning "Current lab requires .NET 4.5+ Full installed.`nPlease install it from internet and re-run this script."
 	Break
 }


### PR DESCRIPTION
- When running TestPrereq.ps1, it gives the following error: "WARNING: Current lab requires .NET 4.5+ Full installed. Please install it from internet and re-run this script.”.  Digging into the script, it is checking for 4.5.\* from the registry.  When I look at the actual registry value, it is 4.6.xxx. 
- After running the install script, I got an error stating that the TrainingLabWCFService failed to start.  Looking at error logs, this was because the NetTcpPortSharing service was disabled.  After setting this service to start automatically and starting it, I was able to successfully start the WCF service.
- The AJAX virtual directory WCF service was throwing 404’s, and it turns out it was because only 1/5 WCF features were enabled. After enabling all WCF features in server manager (not sure which one(s) were required), this service started running fine.
